### PR TITLE
Handle cursor going over canvas edge

### DIFF
--- a/frontend/classes/Player.js
+++ b/frontend/classes/Player.js
@@ -2,30 +2,28 @@ import { playerCanvas } from '../utils/canvas.js'
 
 class Player {
   constructor(ctx) {
-    this.x = 200
+    this.x = playerCanvas.clientWidth / 2
     this.y = 750
     this.ctx = ctx
     this.thickness = 20
     this.length = 60
-    this.dx = 15
-    this.prevX
-    playerCanvas.addEventListener('mousemove', this.handleMouseMove.bind(this))
+    this.dx = 10
+    this.isCursorOutOfLeftBound = false
+    this.isCursorOutOfRightBound = false
+    this.isDirectionChanged = false
+    document.addEventListener('mousemove', this.handleMouseMove.bind(this))
   }
 
   handleMouseMove(event) {
-    const cursorPos = event.offsetX
-    const isMovingLeft = event.movementX < 0
-    if (isMovingLeft) {
-      if (this.x > cursorPos) {
-        this.x -= this.dx
-      }
-    } else {
-      if (
-        this.x <= cursorPos &&
-        this.x + this.length <= playerCanvas.clientWidth
-      ) {
-        this.x += this.dx
-      }
+    const cursorPos = event.clientX - playerCanvas.getBoundingClientRect().x - this.length / 2
+    if (cursorPos <= 0) {
+      this.x = 0
+    }
+    else if ( cursorPos >= playerCanvas.clientWidth - this.length) {
+      this.x = playerCanvas.clientWidth - this.length
+    }
+    else {
+      this.x = cursorPos
     }
   }
 

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
   <body>
     <button id="helloButton">Say Hello</button>
     <div class="game-container">
-      <canvas id="canvasA" tabindex="0" width="880" height="800"></canvas>
+      <canvas id="canvasA" tabindex="0" width="480" height="800"></canvas>
     </div>
     <script src="/socket.io/socket.io.js"></script>
     <script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -11,7 +11,7 @@ body {
 
 .game-container {
   border: 1px solid black;
-  width: 880px;
+  width: 480px;
   height: 800px;
   margin: 0 auto;
 }
@@ -19,5 +19,4 @@ body {
 .game-container canvas {
   background-color: black;
   image-rendering: pixelated;
-  cursor: none;
 }


### PR DESCRIPTION
When the mouse cursor moves too fast and over the canvas, the paddle suddenly stops without reaching the far left/right edge of the canvas. We want to update the paddle movement logic such that when the mouse cursor is over the left/right edge of the canvas, the paddle should be placed on the far left/right corner of the canvas.