### PR TITLE
Map bubbles onto canvas

### DIFF
--- a/frontend/classes/Ball.js
+++ b/frontend/classes/Ball.js
@@ -4,11 +4,11 @@ class Ball {
     this.x = 240
     this.y = 500
     this.dx = 0
-    this.dy = 1
+    this.dy = 5
     this.angle = 90
     this.speed = this.dy
     this.radius = 10
-    ctx.fillStyle = 'blue'
+    ctx.fillStyle = 'white'
   }
 
   draw() {

--- a/frontend/classes/Bubble.js
+++ b/frontend/classes/Bubble.js
@@ -1,15 +1,28 @@
+import { playerCanvasCtx } from '../utils/canvas.js'
+
 class Bubble {
-  constructor() {
+  constructor(x, y, hp) {
     this.image = new Image()
     this.image.src = 'images/sphere40.png'
     this.image.onload = () => {
       this.isLoaded = true
     }
+    this.x = x
+    this.y = y
+    this.hp = hp
+    this.radius = 20
+    this.centerX = this.x + this.radius
+    this.centerY = this.y + this.radius
   }
 
-  draw(ctx, x, y) {
-    this.isLoaded && ctx.drawImage(this.image, x, y)
-    // ctx.drawImage(this.image, x, y)
+  setHp(hp) {
+    this.hp = hp
+  }
+
+  draw() {
+    if (this.isLoaded && this.hp > 0) {
+      playerCanvasCtx.drawImage(this.image, this.x, this.y)
+    }
   }
 }
 

--- a/frontend/classes/Bubble.js
+++ b/frontend/classes/Bubble.js
@@ -1,7 +1,7 @@
 import { playerCanvasCtx } from '../utils/canvas.js'
 
 class Bubble {
-  constructor(x, y, hp) {
+  constructor(x, y, hp = 0) {
     this.image = new Image()
     this.image.src = 'images/sphere40.png'
     this.image.onload = () => {

--- a/frontend/classes/Player.js
+++ b/frontend/classes/Player.js
@@ -3,7 +3,7 @@ import { playerCanvas } from '../utils/canvas.js'
 class Player {
   constructor(ctx) {
     this.x = playerCanvas.clientWidth / 2 - 30
-    this.y = 750
+    this.y = 800
     this.ctx = ctx
     this.thickness = 20
     this.length = 60
@@ -29,7 +29,7 @@ class Player {
 
   draw() {
     this.ctx.lineWidth = this.thickness
-    this.ctx.strokeStyle = 'red'
+    this.ctx.strokeStyle = 'white'
     this.ctx.beginPath()
     this.ctx.moveTo(this.x, this.y)
     this.ctx.lineTo(this.x + this.length, this.y)

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,5 +1,4 @@
 import Ball from './classes/Ball.js'
-import Bubble from './classes/Bubble.js'
 import Player from './classes/Player.js'
 import { mapDefault } from './maps.js'
 import { playerCanvas, playerCanvasCtx } from './utils/canvas.js'
@@ -7,6 +6,11 @@ import { handleCollisions } from './utils/collision.js'
 
 const player = new Player(playerCanvasCtx)
 const ball = new Ball(playerCanvasCtx)
+
+function drawLoop() {
+  ball.update()
+  player.draw()
+}
 
 setTimeout(() => {
   for (const bubble of Object.values(mapDefault)) {
@@ -28,11 +32,8 @@ function render() {
     playerCanvas.clientWidth,
     playerCanvas.clientHeight
   )
-  ball.update()
-  player.draw()
-  for (const bubble of Object.values(mapDefault)) {
-    bubble.draw()
-  }
+
+  drawLoop()
   handleCollisions(ball, player)
   window.requestAnimationFrame(render)
 }

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,10 +1,18 @@
 import Ball from './classes/Ball.js'
+import Bubble from './classes/Bubble.js'
 import Player from './classes/Player.js'
+import { mapDefault } from './maps.js'
 import { playerCanvas, playerCanvasCtx } from './utils/canvas.js'
 import { handleCollisions } from './utils/collision.js'
 
 const player = new Player(playerCanvasCtx)
 const ball = new Ball(playerCanvasCtx)
+
+setTimeout(() => {
+  for (const bubble of Object.values(mapDefault)) {
+    bubble.draw()
+  }
+}, 200)
 
 socket.on('connect', () => {
   socket.on('updateConnections', (players) => {
@@ -14,9 +22,17 @@ socket.on('connect', () => {
 })
 
 function render() {
-  playerCanvasCtx.clearRect(0, 0, playerCanvas.width, 800)
+  playerCanvasCtx.clearRect(
+    0,
+    0,
+    playerCanvas.clientWidth,
+    playerCanvas.clientHeight
+  )
   ball.update()
   player.draw()
+  for (const bubble of Object.values(mapDefault)) {
+    bubble.draw()
+  }
   handleCollisions(ball, player)
   window.requestAnimationFrame(render)
 }

--- a/frontend/maps.js
+++ b/frontend/maps.js
@@ -1,21 +1,23 @@
-const mapDefault = [
-  [0, 0],
-  [40, 0],
-  [80, 0],
-  [160, 0],
-  [200, 0],
-  [240, 0],
-  [320, 0],
-  [400, 0],
+import Bubble from './classes/Bubble.js'
 
-  [0, 40],
-  [40, 40],
-  [80, 40],
-  [160, 40],
-  [200, 40],
-  [240, 40],
-  [320, 40],
-  [400, 40]
-]
+/**
+ * Map of blocks to break.
+ * 20 Rows * 12 Columns
+ * x= 0, 40, 80, 120, 160, 200, 240, 280, 320, 360, 400, 440, 480
+ * y= 0,  40, 80, 120, 160, 200, 240, 280, 320, 360, 400, 440, 480 ... 800
+ */
+const coordinates = {}
+const ROWS = 20
+const COLS = 12
+
+for (let i = 0; i <= COLS; i++) {
+  for (let j = 0; j <= ROWS; j++) {
+    coordinates[`c${i}r${j}`] = new Bubble(i * 40, j * 40, 0)
+  }
+}
+
+const mapDefault = { ...coordinates }
+mapDefault[`c0r0`].setHp(1)
+console.log('mapDefault:', mapDefault)
 
 export { mapDefault }

--- a/frontend/maps.js
+++ b/frontend/maps.js
@@ -1,10 +1,10 @@
 import Bubble from './classes/Bubble.js'
 
 /**
- * Map of blocks to break.
+ * Map of bubbles to pop.
  * 20 Rows * 12 Columns
- * x= 0, 40, 80, 120, 160, 200, 240, 280, 320, 360, 400, 440, 480
- * y= 0,  40, 80, 120, 160, 200, 240, 280, 320, 360, 400, 440, 480 ... 800
+ * x= 0, 40, 80, ... , 480
+ * y= 0, 40, 80, ... , 800
  */
 const coordinates = {}
 const ROWS = 20
@@ -12,12 +12,12 @@ const COLS = 12
 
 for (let i = 0; i <= COLS; i++) {
   for (let j = 0; j <= ROWS; j++) {
-    coordinates[`c${i}r${j}`] = new Bubble(i * 40, j * 40, 0)
+    coordinates[`c${i}r${j}`] = new Bubble(i * 40, j * 40)
   }
 }
 
 const mapDefault = { ...coordinates }
 mapDefault[`c0r0`].setHp(1)
-console.log('mapDefault:', mapDefault)
+mapDefault[`c11r15`].setHp(1)
 
 export { mapDefault }

--- a/frontend/utils/collision.js
+++ b/frontend/utils/collision.js
@@ -1,5 +1,6 @@
 import Ball from '../classes/Ball.js'
 import Player from '../classes/Player.js'
+import { mapDefault } from '../maps.js'
 import { playerCanvas } from './canvas.js'
 
 /**
@@ -34,6 +35,19 @@ function handleCollisions(ball, player) {
   // Ball has hit the upper wall
   if (ball.y - ball.radius <= 0) {
     ball.dy *= -1
+  }
+
+  // Ball has hit a bubble
+  for (const bubble of Object.values(mapDefault)) {
+    const distance = Math.sqrt(
+      Math.abs(bubble.centerX - ball.x) ** 2 +
+        Math.abs(bubble.centerY - ball.y) ** 2
+    )
+    if (bubble.hp > 0 && distance <= bubble.radius + ball.radius) {
+      bubble.setHp(0)
+      ball.dx *= -1
+    }
+    bubble.draw()
   }
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
   <body>
     <button id="helloButton">Say Hello</button>
     <div class="game-container">
-      <canvas id="canvasA" tabindex="0" width="480" height="800"></canvas>
+      <canvas id="canvasA" tabindex="0" width="480" height="880"></canvas>
     </div>
     <script src="/socket.io/socket.io.js"></script>
     <script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -12,7 +12,7 @@ body {
 .game-container {
   border: 1px solid black;
   width: 480px;
-  height: 800px;
+  height: 880px;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
This PR achieves two two things:
1) Map bubbles onto the canvas
2) Add basic collision logic between the ball and the bubbles. 
 

### Mapping bubbles onto the canvas

* Each bubble is identified by a unique identifier (string) with the following format:
`c${i}r${j}` where `i` is the column number and `j` is the row number of the bubble.
* Each bubble is visible on the canvas if it has `hp` > 0. If not, it is invisible. In the future, there will be bubbles that require multiple hits to be broken, hence the hp property.

### Collision logic

* Collision logic is based on the distance between the center point of the ball and the bubble. If the distance is less than or equal to the ball.radius + bubble.radius, a collision is deemed to have occurred. The distance calculation simply uses the Pythagorean equation:
`distance between ball and radius =  sqrt( (| ball.x - bubble.x |)^2 + (| ball.y - bubble.y |)^2 )`

For now, the ball only reverses its x direction when it collides with a bubble. In the future, I will make it so that its direction changes horizontally or vertically or both, depending on where on the bubble the ball hits.